### PR TITLE
Added basic layout for TrendingArtist component

### DIFF
--- a/src/components/Artists/ArtistImage/ArtistImage.js
+++ b/src/components/Artists/ArtistImage/ArtistImage.js
@@ -1,13 +1,14 @@
-import React from "react";
+import React from 'react';
 
-const ArtistImage =() => {
-    return (<div className="artist-image">
-        <img
+const ArtistImage = () => {
+  return (
+    <div className="artist-image">
+      <img
         className="artist-image__avatar"
         src="/images/dua_lipa_profile.jpg"
         alt="Dua Lipa profile"
-        />
-        <h5 className="artist-image__name white">Dua Lipa</h5>
-    </div>);
-}
+      />
+    </div>
+  );
+};
 export default ArtistImage;

--- a/src/components/Artists/ArtistImage/ArtistImage.scss
+++ b/src/components/Artists/ArtistImage/ArtistImage.scss
@@ -1,18 +1,9 @@
 .artist-image {
-    vertical-align: top;
-    display: inline-block;
-    text-align: center;
-    width: 120px;
+  vertical-align: top;
+  display: inline-block;
+  text-align: center;
 }
 
 .artist-image__avatar {
-    width: 100px;
-    height: 100px;
+  width: 220px;
 }
-
-.artist-image__name {
-    display: block;
-}
-
-
-

--- a/src/components/Artists/ArtistImage/ArtistImage.test.js
+++ b/src/components/Artists/ArtistImage/ArtistImage.test.js
@@ -4,12 +4,8 @@ import ArtistImage from './ArtistImage';
 import { shallow } from 'enzyme';
 
 describe('ArtistImage', () => {
-  let artistImageWrapper;
-  beforeEach(() => {
-    artistImageWrapper = shallow(<ArtistImage />);
-  });
-
   it('has an image of the artist', () => {
+    const artistImageWrapper = shallow(<ArtistImage />);
     expect(artistImageWrapper.find('img').length).toEqual(1);
   });
 });

--- a/src/components/Artists/ArtistImage/ArtistImage.test.js
+++ b/src/components/Artists/ArtistImage/ArtistImage.test.js
@@ -1,22 +1,15 @@
-import React from 'react'
-import ArtistImage from './ArtistImage'
+import React from 'react';
+import ArtistImage from './ArtistImage';
 
-import {
-  shallow
-} from 'enzyme'
+import { shallow } from 'enzyme';
 
 describe('ArtistImage', () => {
-
-  let artistImageWrapper
+  let artistImageWrapper;
   beforeEach(() => {
-    artistImageWrapper = shallow( < ArtistImage/> )
-  })
+    artistImageWrapper = shallow(<ArtistImage />);
+  });
 
   it('has an image of the artist', () => {
-    expect(artistImageWrapper.find('img').length).toEqual(1)
-  })
-
-  it('has the artist name', () => {
-      expect(artistImageWrapper.find('h5').text()).toEqual('Dua Lipa')
-  })
-})
+    expect(artistImageWrapper.find('img').length).toEqual(1);
+  });
+});

--- a/src/components/Artists/TrendingArtist/TrendingArtist.js
+++ b/src/components/Artists/TrendingArtist/TrendingArtist.js
@@ -1,7 +1,21 @@
-import React from "react";
-import ArtistImage from "../ArtistImage/ArtistImage";
+import React from 'react';
+import ArtistImage from '../ArtistImage/ArtistImage';
 
-const TrendingArtist =() => {
-    return <div className="trending-artist"><ArtistImage /></div>;
-}
+const TrendingArtist = () => {
+  return (
+    <div className="trending-artist">
+      <ArtistImage />
+      <p className="trending-artist-name">Dua Lipa</p>
+      <p>Awesome Artist A</p>
+      <hr />
+      <div className="trending-artist-detail">
+        <p>Supported Causes: 6</p>
+        <p>Performances: 3</p>
+        <p>Funds Raised: </p>
+      </div>
+      <p className="trending-artist-funds">$3000</p>
+      <button>Learn More</button>
+    </div>
+  );
+};
 export default TrendingArtist;

--- a/src/components/Artists/TrendingArtist/TrendingArtist.scss
+++ b/src/components/Artists/TrendingArtist/TrendingArtist.scss
@@ -1,3 +1,32 @@
 .trending-artist {
-    width: 100%
+  grid-column-end: span 3;
+  border: 1px solid rgba($primary-color-white, 0.6);
+  margin: $padding-s;
+  padding: $padding-s;
+  color: $primary-color-white;
+  font-size: 1.1rem;
+  text-align: center;
+}
+
+.trending-artist hr {
+  border-color: rgba($primary-color-white, 0.6);
+}
+
+.trending-artist-name {
+  font-size: 1.6rem;
+  margin-top: 1rem;
+}
+
+.trending-artist-detail {
+  text-align: left;
+}
+
+.trending-artist-funds {
+  font-size: 1.4rem;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.trending-artist button {
+  margin: 0.9rem 0 0.1rem;
 }

--- a/src/containers/Artists/TrendingArtists/TrendingArtists.js
+++ b/src/containers/Artists/TrendingArtists/TrendingArtists.js
@@ -1,19 +1,17 @@
-import React, { Component } from "react";
-import TrendingArtist from '../../../components/Artists/TrendingArtist/TrendingArtist'
+import React, { Component } from 'react';
+import TrendingArtist from '../../../components/Artists/TrendingArtist/TrendingArtist';
 
 class TrendingArtists extends Component {
   render() {
     return (
-      <div className="trending-artists-container">
+      <React.Fragment>
         <h1 className="trending-artists-title">Trending Artists</h1>
-        <div className='trending-artists'>
-          < TrendingArtist />
-          < TrendingArtist />
-          < TrendingArtist />
-          < TrendingArtist />
-        </div>
-      </div>
-      );
+        <TrendingArtist />
+        <TrendingArtist />
+        <TrendingArtist />
+        <TrendingArtist />
+      </React.Fragment>
+    );
   }
 }
 

--- a/src/containers/Artists/TrendingArtists/TrendingArtists.scss
+++ b/src/containers/Artists/TrendingArtists/TrendingArtists.scss
@@ -1,12 +1,6 @@
-.trending-artists {
-    color: $primary-color-white;
-    display: flex; 
-    justify-content: space-between
-}
-
 .trending-artists-title {
-    font-size: 25px;
-    display: block;
-    color: $primary-color-white;
-    text-align: center;
+  text-align: center;
+  grid-column-end: span 12;
+  padding: $padding-s;
+  color: $primary-color-white;
 }


### PR DESCRIPTION
- Added basic layout and styling for the TrendingArtist component
- Moved the artist name from the ArtistImage component to the TrendingArtist parent component. I did this because I thought that the name would need to be styled according to the parent container and may not be wanted if the ArtistImage component was used elsewhere.
- In the TrendingArtists container, the h1 and TrendingArtist components are being laid out according to the parent 12 column grid instead of the existing flexbox container. I believe this to be the intended use of the grid layout for the site.

fixes #148 