### PR TITLE
Added Explore Artists container

### DIFF
--- a/src/containers/Artists/Artists.js
+++ b/src/containers/Artists/Artists.js
@@ -1,9 +1,15 @@
 import React, { Component } from 'react'
 import TrendingArtists from './TrendingArtists/TrendingArtists'
+import ExploreArtists from './ExploreArtists/ExploreArtists'
 
 class Artists extends Component {
   render() {
-    return <TrendingArtists />
+    return (
+      <React.Fragment>
+        <TrendingArtists />
+        <ExploreArtists />
+      </React.Fragment>
+    )
   }
 }
 

--- a/src/containers/Artists/ExploreArtists/ExploreArtists.js
+++ b/src/containers/Artists/ExploreArtists/ExploreArtists.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+import ArtistImage from '../../../components/Artists/ArtistImage/ArtistImage'
+
+class ExploreArtists extends Component {
+  render() {
+    return (
+      <React.Fragment>
+        <h1 className="explore-artists-title">Explore Artists</h1>
+        <ArtistImage />
+      </React.Fragment>
+    )
+  }
+}
+
+export default ExploreArtists

--- a/src/containers/Artists/ExploreArtists/ExploreArtists.scss
+++ b/src/containers/Artists/ExploreArtists/ExploreArtists.scss
@@ -1,0 +1,7 @@
+.explore-artists-title {
+    text-align: center;
+    grid-column-end: span 12;
+    padding: $padding-s;
+    color: $primary-color-white;
+    margin-top: $margin-l;
+}

--- a/src/containers/Artists/ExploreArtists/ExploreArtists.test.js
+++ b/src/containers/Artists/ExploreArtists/ExploreArtists.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import ExploreArtists from './ExploreArtists'
+import {
+  shallow
+} from 'enzyme'
+
+describe('<ExploreArtists />', () => {
+  let ExploreArtistsWrapper
+  beforeEach(() => {
+    ExploreArtistsWrapper = shallow(<ExploreArtists />)
+  })
+  it('Has 1 Artist', () => {
+    expect(ExploreArtistsWrapper.find('ArtistImage').length).toEqual(1)
+  })
+  it("has 'Explore Artists' title", () => {
+    expect(ExploreArtistsWrapper.find('h1').text()).toEqual('Explore Artists')
+  })
+})

--- a/src/main.scss
+++ b/src/main.scss
@@ -20,4 +20,5 @@
 @import "containers/Artist/RelatedArtists/RelatedArtists.scss";
 @import "containers/Artists/TrendingArtists/TrendingArtists.scss";
 @import "components/Artists/TrendingArtist/TrendingArtist.scss";
+@import "containers/Artists/ExploreArtists/ExploreArtists.scss";
 @import "components/Artists/ArtistImage/ArtistImage.scss"


### PR DESCRIPTION
- Added Explore Artists container with test to the Artists Page
- Left one ArtistImage component within Explore Artists to remind us we need to create either a separate ExploreArtist component or refactor a card component as mentioned below 👇

Suggestion:
- We probably need another ticket that refactors the trending artists and the explore artists artist cards to make something re-usable, so the Explore Artists container and the Trending Artists can share

Fixes #165 