### PR TITLE
199 add pagination to exploreartists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/containers/Artists/ExploreArtists/ExploreArtists.js
+++ b/src/containers/Artists/ExploreArtists/ExploreArtists.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import ArtistCard from '../../../components/Artists/ArtistCard/ArtistCard'
+import ReactPaginate from 'react-paginate'
 
 class ExploreArtists extends Component {
   render() {
@@ -9,6 +10,19 @@ class ExploreArtists extends Component {
         <ArtistCard artistName={'Dua Lipa'} />
         <ArtistCard artistName={'Dua Lipa'} />
         <ArtistCard artistName={'Dua Lipa'} />
+        <ReactPaginate
+          previousLabel={'previous'}
+          nextLabel={'next'}
+          breakLabel={'...'}
+          breakClassName={'break-me'}
+          pageCount={2}
+          marginPagesDisplayed={1}
+          pageRangeDisplayed={3}
+          onPageChange={this.handlePageClick}
+          containerClassName={'pagination'}
+          subContainerClassName={'pages pagination'}
+          activeClassName={'active'}
+        />
       </React.Fragment>
     )
   }

--- a/src/containers/Artists/ExploreArtists/ExploreArtists.test.js
+++ b/src/containers/Artists/ExploreArtists/ExploreArtists.test.js
@@ -4,17 +4,17 @@ import { shallow } from 'enzyme'
 import ReactPaginate from 'react-paginate'
 
 describe('<ExploreArtists />', () => {
-  let ExploreArtistsWrapper
+  let exploreArtistsWrapper
   beforeEach(() => {
-    ExploreArtistsWrapper = shallow(<ExploreArtists />)
+    exploreArtistsWrapper = shallow(<ExploreArtists />)
   })
   it('Has 3 Artists', () => {
-    expect(ExploreArtistsWrapper.find('ArtistCard').length).toEqual(3)
+    expect(exploreArtistsWrapper.find('ArtistCard').length).toEqual(3)
   })
   it("has 'Explore Artists' title", () => {
-    expect(ExploreArtistsWrapper.find('h1').text()).toEqual('Explore Artists')
+    expect(exploreArtistsWrapper.find('h1').text()).toEqual('Explore Artists')
   })
-  it('adds a pagination component', () => {
-    expect(ExploreArtistsWrapper.find(ReactPaginate).length).toEqual(1)
+  it('has a pagination component', () => {
+    expect(exploreArtistsWrapper.find(ReactPaginate).length).toEqual(1)
   })
 })

--- a/src/containers/Artists/ExploreArtists/ExploreArtists.test.js
+++ b/src/containers/Artists/ExploreArtists/ExploreArtists.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ExploreArtists from './ExploreArtists'
 import { shallow } from 'enzyme'
+import ReactPaginate from 'react-paginate'
 
 describe('<ExploreArtists />', () => {
   let ExploreArtistsWrapper
@@ -12,5 +13,8 @@ describe('<ExploreArtists />', () => {
   })
   it("has 'Explore Artists' title", () => {
     expect(ExploreArtistsWrapper.find('h1').text()).toEqual('Explore Artists')
+  })
+  it('adds a pagination component', () => {
+    expect(ExploreArtistsWrapper.find(ReactPaginate).length).toEqual(1)
   })
 })


### PR DESCRIPTION
### What does this PR do?
1. Adds the pagination component to the ExploreArtists component.
2. Adds .vscode to .gitignore

#### Description of Task to be completed?
Simply import ReactPaginate and add the component. Mirrors #197 

#### How should this be manually tested?
Go to ExploreArtists component and look for the component

#### Any background context you want to provide?
N/A

#### What are the relevant Github Issues ?

Fixes #199 

#### Screenshots (If applicable)
![Screenshot from 2019-05-04 14-02-31](https://user-images.githubusercontent.com/2614417/57183639-8b5f0500-6e75-11e9-8c63-188cc132c7ef.png)
