### PR TITLE
Added styling to supporting artists and related caues also fixed the …

### DIFF
--- a/src/components/Cause/Campaign/Campaign.scss
+++ b/src/components/Cause/Campaign/Campaign.scss
@@ -1,7 +1,8 @@
 .campaign-container {
   grid-row: 1;
-  grid-column: 8/-1;
+  grid-column: 7/-1;
   display: flex;
+  margin-left: $margin-l;
   margin-bottom: $margin-l;
   margin-top: $margin-l;
   padding: $padding-r;

--- a/src/components/Cause/RelatedCause/RelatedCause.js
+++ b/src/components/Cause/RelatedCause/RelatedCause.js
@@ -4,15 +4,13 @@ import { faUserCircle } from '@fortawesome/free-solid-svg-icons'
 
 const RelatedCause = () => {
   return (
-    <React.Fragment>
+    <div className="related-cause">
       <FontAwesomeIcon
         className="related-cause__icon white"
         icon={faUserCircle}
       />
-      <div className="white">
-          Deserving cause A
-      </div>
-    </React.Fragment>
+      <div className="white">Deserving cause A</div>
+    </div>
   )
 }
 

--- a/src/components/Cause/RelatedCause/RelatedCause.scss
+++ b/src/components/Cause/RelatedCause/RelatedCause.scss
@@ -1,0 +1,9 @@
+.related-cause {
+  display: flex;
+  align-items: center;
+  margin-bottom: $margin-xs;
+
+  .related-cause__icon {
+    margin-right: $margin-xs;
+  }
+}

--- a/src/components/Cause/RelatedCause/RelatedCause.test.js
+++ b/src/components/Cause/RelatedCause/RelatedCause.test.js
@@ -10,7 +10,9 @@ describe('RelatedCause', () => {
   })
 
   it('has a div with text Deserving cause A', () => {
-    expect(relatedCauseWrapper.find('div').text()).toEqual('Deserving cause A')
+    expect(relatedCauseWrapper.find('div.white').text()).toEqual(
+      'Deserving cause A'
+    )
   })
 
   it('has an FontAwesomeIcon of the cause', () => {

--- a/src/components/Cause/SupportingArtist/SupportingArtist.js
+++ b/src/components/Cause/SupportingArtist/SupportingArtist.js
@@ -4,15 +4,13 @@ import { faUserCircle } from '@fortawesome/free-solid-svg-icons'
 
 const SupportingArtist = () => {
   return (
-    <React.Fragment>
+    <div className="supporting-artist">
       <FontAwesomeIcon
         className="supporting-artist__icon white"
         icon={faUserCircle}
       />
-      <div className="white">
-        Awesome artist A
-      </div>
-    </React.Fragment>
+      <div className="white">Awesome artist A</div>
+    </div>
   )
 }
 

--- a/src/components/Cause/SupportingArtist/SupportingArtist.scss
+++ b/src/components/Cause/SupportingArtist/SupportingArtist.scss
@@ -1,0 +1,9 @@
+.supporting-artist {
+  display: flex;
+  align-items: center;
+  margin-bottom: $margin-xs;
+
+  .supporting-artist__icon {
+    margin-right: $margin-xs;
+  }
+}

--- a/src/components/Cause/SupportingArtist/SupportingArtist.test.js
+++ b/src/components/Cause/SupportingArtist/SupportingArtist.test.js
@@ -10,7 +10,9 @@ describe('SupportingArtist', () => {
   })
 
   it('has a div with text Awesome artist A', () => {
-    expect(supportingArtistWrapper.find('div').text()).toEqual('Awesome artist A')
+    expect(supportingArtistWrapper.find('div.white').text()).toEqual(
+      'Awesome artist A'
+    )
   })
 
   it('has an FontAwesomeIcon of the artist', () => {

--- a/src/containers/Cause/Cause.js
+++ b/src/containers/Cause/Cause.js
@@ -20,10 +20,10 @@ class Cause extends Component {
           daysToGo={12}
           organization="UNICEF"
         />
-        <ContactUs />
         <SupportingArtists />
         <RelatedCauses />
         <RecentDonors />
+        <ContactUs />
       </React.Fragment>
     )
   }

--- a/src/containers/Cause/RelatedCauses/RelatedCauses.js
+++ b/src/containers/Cause/RelatedCauses/RelatedCauses.js
@@ -4,12 +4,13 @@ import RelatedCause from '../../../components/Cause/RelatedCause/RelatedCause'
 class RelatedCauses extends Component {
   render() {
     return (
-      <React.Fragment>
+      <div className="related-causes-wrapper">
+        <h5 className="white">Related causes</h5>
         <RelatedCause />
         <RelatedCause />
         <RelatedCause />
         <RelatedCause />
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/src/containers/Cause/RelatedCauses/RelatedCauses.scss
+++ b/src/containers/Cause/RelatedCauses/RelatedCauses.scss
@@ -1,0 +1,9 @@
+.related-causes-wrapper {
+  grid-row: 2;
+  grid-column: 10/-1;
+  margin-left: $margin-r;
+
+  h5 {
+    margin-bottom: $margin-s;
+  }
+}

--- a/src/containers/Cause/RelatedCauses/RelatedCauses.test.js
+++ b/src/containers/Cause/RelatedCauses/RelatedCauses.test.js
@@ -13,4 +13,8 @@ describe('RelatedCauses', () => {
   it('has 4 related cause components', () => {
     expect(relatedCausesWrapper.find('RelatedCause').length).toEqual(4)
   })
+
+  it('has Related causes title', () => {
+    expect(relatedCausesWrapper.find('h5').text()).toEqual('Related causes')
+  })
 })

--- a/src/containers/Cause/SupportingArtists/SupportingArtists.js
+++ b/src/containers/Cause/SupportingArtists/SupportingArtists.js
@@ -4,12 +4,13 @@ import SupportingArtist from '../../../components/Cause/SupportingArtist/Support
 class SupportingArtists extends Component {
   render() {
     return (
-      <React.Fragment>
+      <div className="supporting-artists-wrapper">
+        <h5 className="white">Supporting artists</h5>
         <SupportingArtist />
         <SupportingArtist />
         <SupportingArtist />
         <SupportingArtist />
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/src/containers/Cause/SupportingArtists/SupportingArtists.scss
+++ b/src/containers/Cause/SupportingArtists/SupportingArtists.scss
@@ -1,0 +1,9 @@
+.supporting-artists-wrapper {
+  grid-row: 2;
+  grid-column: 7/10;
+  margin-left: $margin-l;
+
+  h5 {
+    margin-bottom: $margin-s;
+  }
+}

--- a/src/containers/Cause/SupportingArtists/SupportingArtists.test.js
+++ b/src/containers/Cause/SupportingArtists/SupportingArtists.test.js
@@ -13,4 +13,10 @@ describe('SupportingArtists', () => {
   it('has 4 SupportingArtist components', () => {
     expect(supportingArtistsWrapper.find('SupportingArtist').length).toEqual(4)
   })
+
+  it('has Supporting artists title', () => {
+    expect(
+      supportingArtistsWrapper.find('div.supporting-artists-wrapper h5').text()
+    ).toEqual('Supporting artists')
+  })
 })

--- a/src/main.scss
+++ b/src/main.scss
@@ -36,4 +36,6 @@
 @import "components/Cause/Donate/Donate.scss";
 @import "components/Cause/Campaign/Campaign.scss";
 @import "components/Cause/ContactUs/ContactUs.scss";
+@import "components/Cause/SupportingArtist/SupportingArtist.scss";
+@import "components/Cause/RelatedCause/RelatedCause.scss";
 @import "components/Causes/CauseCard/CauseCard.scss";


### PR DESCRIPTION
Fixes #251 

- Added styling to Supporting artists and Related causes elements on cause page
- Fixed the wrapping grid around the content to match better the mockups
- Added Supporting artists title and Related causes title

Further improvement:
- When the avatar component will be ready both the related artists, and the related causes can be avatars instead of icons

![Screen Shot 2019-05-14 at 7 25 09 PM](https://user-images.githubusercontent.com/9334646/57718942-e915fd00-767e-11e9-911c-8423860a5c7b.png)
