### PR TITLE
256 change icons to avatars

### DIFF
--- a/src/components/Cause/RelatedCause/RelatedCause.js
+++ b/src/components/Cause/RelatedCause/RelatedCause.js
@@ -1,15 +1,11 @@
 import React from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUserCircle } from '@fortawesome/free-solid-svg-icons'
+import Avatar from '../../Shared/Avatar/Avatar'
 
 const RelatedCause = () => {
   return (
     <div className="related-cause">
-      <FontAwesomeIcon
-        className="related-cause__icon white"
-        icon={faUserCircle}
-      />
-      <div className="white">Deserving cause A</div>
+      <Avatar />
+      <div className="white related-cause__name">Deserving cause A</div>
     </div>
   )
 }

--- a/src/components/Cause/RelatedCause/RelatedCause.scss
+++ b/src/components/Cause/RelatedCause/RelatedCause.scss
@@ -3,7 +3,7 @@
   align-items: center;
   margin-bottom: $margin-xs;
 
-  .related-cause__icon {
-    margin-right: $margin-xs;
+  .related-cause__name {
+    margin-left: $margin-xs;
   }
 }

--- a/src/components/Cause/RelatedCause/RelatedCause.test.js
+++ b/src/components/Cause/RelatedCause/RelatedCause.test.js
@@ -15,7 +15,7 @@ describe('RelatedCause', () => {
     )
   })
 
-  it('has an FontAwesomeIcon of the cause', () => {
-    expect(relatedCauseWrapper.find('FontAwesomeIcon').length).toEqual(1)
+  it('has an Avatar component', () => {
+    expect(relatedCauseWrapper.find('Avatar').length).toEqual(1)
   })
 })

--- a/src/components/Cause/SupportingArtist/SupportingArtist.js
+++ b/src/components/Cause/SupportingArtist/SupportingArtist.js
@@ -1,15 +1,11 @@
 import React from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUserCircle } from '@fortawesome/free-solid-svg-icons'
+import Avatar from '../../Shared/Avatar/Avatar'
 
 const SupportingArtist = () => {
   return (
     <div className="supporting-artist">
-      <FontAwesomeIcon
-        className="supporting-artist__icon white"
-        icon={faUserCircle}
-      />
-      <div className="white">Awesome artist A</div>
+      <Avatar />
+      <div className="white supporting-artist__name">Awesome artist A</div>
     </div>
   )
 }

--- a/src/components/Cause/SupportingArtist/SupportingArtist.scss
+++ b/src/components/Cause/SupportingArtist/SupportingArtist.scss
@@ -3,7 +3,7 @@
   align-items: center;
   margin-bottom: $margin-xs;
 
-  .supporting-artist__icon {
-    margin-right: $margin-xs;
+  .supporting-artist__name {
+    margin-left: $margin-xs;
   }
 }

--- a/src/components/Cause/SupportingArtist/SupportingArtist.test.js
+++ b/src/components/Cause/SupportingArtist/SupportingArtist.test.js
@@ -15,7 +15,7 @@ describe('SupportingArtist', () => {
     )
   })
 
-  it('has an FontAwesomeIcon of the artist', () => {
-    expect(supportingArtistWrapper.find('FontAwesomeIcon').length).toEqual(1)
+  it('has an Avatar component', () => {
+    expect(supportingArtistWrapper.find('Avatar').length).toEqual(1)
   })
 })

--- a/src/containers/Artist/RelatedArtists/RelatedArtists.js
+++ b/src/containers/Artist/RelatedArtists/RelatedArtists.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUserCircle } from '@fortawesome/free-solid-svg-icons'
+import Avatar from '../../../components/Shared/Avatar/Avatar'
 
 const RelatedArtists = () => {
   return (
@@ -9,31 +8,19 @@ const RelatedArtists = () => {
       <div>
         <ul className="related-artists-item-list white">
           <li>
-            <FontAwesomeIcon
-              className="related-artists-item-list__icon"
-              icon={faUserCircle}
-            />
+            <Avatar />
             <span>Awesome Artist A</span>
           </li>
           <li>
-            <FontAwesomeIcon
-              className="related-artists-item-list__icon"
-              icon={faUserCircle}
-            />
+            <Avatar />
             <span>Awesome Artist B</span>
           </li>
           <li>
-            <FontAwesomeIcon
-              className="related-artists-item-list__icon"
-              icon={faUserCircle}
-            />
+            <Avatar />
             <span>Awesome Artist C</span>
           </li>
           <li>
-            <FontAwesomeIcon
-              className="related-artists-item-list__icon"
-              icon={faUserCircle}
-            />
+            <Avatar />
             <span>Awesome Artist D</span>
           </li>
         </ul>

--- a/src/containers/Artist/RelatedArtists/RelatedArtists.test.js
+++ b/src/containers/Artist/RelatedArtists/RelatedArtists.test.js
@@ -15,4 +15,8 @@ describe('<RelatedArtists />', () => {
   it('has a list of 4 Related Artists', () => {
     expect(relatedArtistsWrapper.find('li').length).toEqual(4)
   })
+
+  it('has 4 Avatars', () => {
+    expect(relatedArtistsWrapper.find('Avatar').length).toEqual(4)
+  })
 })

--- a/src/containers/Artist/SupportedCauses/SupportedCauses.js
+++ b/src/containers/Artist/SupportedCauses/SupportedCauses.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faGift } from '@fortawesome/free-solid-svg-icons'
+import Avatar from '../../../components/Shared/Avatar/Avatar'
 
 const SupportedCauses = () => {
   return (
@@ -9,31 +8,19 @@ const SupportedCauses = () => {
       <div>
         <ul className="supported-causes-item-list white">
           <li>
-            <FontAwesomeIcon
-              className="supported-causes-item-list__icon"
-              icon={faGift}
-            />
+            <Avatar />
             <span>Deserving Cause A</span>
           </li>
           <li>
-            <FontAwesomeIcon
-              className="supported-causes-item-list__icon"
-              icon={faGift}
-            />
+            <Avatar />
             <span>Deserving Cause B</span>
           </li>
           <li>
-            <FontAwesomeIcon
-              className="supported-causes-item-list__icon"
-              icon={faGift}
-            />
+            <Avatar />
             <span>Deserving Cause C</span>
           </li>
           <li>
-            <FontAwesomeIcon
-              className="supported-causes-item-list__icon"
-              icon={faGift}
-            />
+            <Avatar />
             <span>Deserving Cause D</span>
           </li>
         </ul>

--- a/src/containers/Artist/SupportedCauses/SupportedCauses.test.js
+++ b/src/containers/Artist/SupportedCauses/SupportedCauses.test.js
@@ -15,6 +15,10 @@ describe('<SupportedCauses />', () => {
   })
 
   it('has a list of 4 Supported Causes', () => {
+    expect(supportedCausesWrapper.find('Avatar').length).toEqual(4)
+  })
+
+  it('has a list of 4 Supported Causes', () => {
     expect(supportedCausesWrapper.find('li').length).toEqual(4)
   })
 })

--- a/src/containers/Cause/RelatedCauses/RelatedCauses.scss
+++ b/src/containers/Cause/RelatedCauses/RelatedCauses.scss
@@ -2,7 +2,8 @@
   grid-row: 2;
   grid-column: 10/-1;
   margin-left: $margin-r;
-
+  margin-bottom: $margin-r;
+  
   h5 {
     margin-bottom: $margin-s;
   }

--- a/src/containers/Cause/SupportingArtists/SupportingArtists.scss
+++ b/src/containers/Cause/SupportingArtists/SupportingArtists.scss
@@ -2,7 +2,7 @@
   grid-row: 2;
   grid-column: 7/10;
   margin-left: $margin-l;
-
+  margin-bottom: $margin-r;
   h5 {
     margin-bottom: $margin-s;
   }


### PR DESCRIPTION
### What does this PR do?

Refactor Related Artist and Causes components to use Avatar component instead of Font Awesome icons

#### How should this be manually tested?

1. On terminal, run command ` yarn start`
2. navigate to `localhost:3000/causes/1`
3. Check that you see th image below


#### What are the relevant Github Issues ?

Fixes #256 

#### Screenshots (If applicable)

<img width="622" alt="Screen Shot 2019-05-18 at 10 39 45 PM" src="https://user-images.githubusercontent.com/1543546/57974254-e6d4db00-79bd-11e9-8016-0ed240fed4cd.png">

