### PR TITLE
Closing mobile menu on body click

### DIFF
--- a/src/components/Layout/NavBar/NavBar.js
+++ b/src/components/Layout/NavBar/NavBar.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars } from '@fortawesome/free-solid-svg-icons'
+import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { NavLink } from 'react-router-dom'
 
 const NavBar = props => {
@@ -36,7 +36,13 @@ const NavBar = props => {
       </div>
       <div className="nav-container__right" />
 
-      <FontAwesomeIcon icon={faBars} className="nav-container__icon" onClick={props.handleClick} />
+      <FontAwesomeIcon
+        icon={props.mobileMenu ? faTimes : faBars}
+        className={`nav-container__icon ${
+          props.mobileMenu ? 'no-pointer' : ''
+        }`}
+        onClick={props.handleClick}
+      />
       <div className="clear-fix" />
     </nav>
   )

--- a/src/containers/Layout/Layout.js
+++ b/src/containers/Layout/Layout.js
@@ -6,18 +6,36 @@ import PropTypes from 'prop-types'
 export default class Layout extends Component {
   state = {
     mobileMenu: false
+  };
+
+  componentDidMount() {
+    document.addEventListener('mouseup', this.handleClickOutside)
   }
+  componentWillUnmount() {
+    document.removeEventListener('mouseup', this.handleClickOutside)
+  }
+
+  handleClickOutside = () => {
+    if (this.state.mobileMenu) {
+      this.setState({
+        mobileMenu: false
+      })
+    }
+  };
 
   handleClick = () => {
     this.setState({
       mobileMenu: !this.state.mobileMenu
     })
-  }
+  };
 
   render() {
     return (
       <div>
-        <Header mobileMenu={this.state.mobileMenu} handleClick={this.handleClick} />
+        <Header
+          mobileMenu={this.state.mobileMenu}
+          handleClick={this.handleClick}
+        />
         {this.props.children}
         <Footer />
       </div>

--- a/src/containers/Layout/Layout.test.js
+++ b/src/containers/Layout/Layout.test.js
@@ -7,7 +7,9 @@ import Layout from './Layout'
 describe('<Layout />', () => {
   let layoutWrapper
   beforeEach(() => {
-    layoutWrapper = shallow(<Layout children={[]} />)
+    layoutWrapper = shallow(<Layout children={[]} />, {
+      disableLifecycleMethods: true
+    })
   })
 
   it('contains a Header component', () => {

--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -14,3 +14,8 @@ $padding-r: 24px;
 $padding-l: 32px;
 $padding-xl: 48px;
 $padding-xxl: 64px;
+
+// POINTER EVENTS
+.no-pointer {
+  pointer-events: none;
+}


### PR DESCRIPTION
### What does this PR do?
 - Added functionality to mobile header to close, when user clicks / taps outside of the menu
 - Added "X" on mobile header to represent the closing behavior

#### Description of Task to be completed?
- The mobile menu should be closed, when user is tapping clicking outside of the menu area or tapping the "X" icon

#### How should this be manually tested?

The regular way of testing forked repos should be enough.
https://github.com/AgileVentures/sfn-client/blob/develop/HOW-TO-REVIEW-A-DEVELOP-PR.md#for-forked-repos

Go to the mobile viewport and the try to open / close the menu with the methods mentioned above!

#### What are the relevant Github Issues ?
Fixes #269 