### PR TITLE
Ignore index js from coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,12 @@
   },
   "standard": {
     "parser": "babel-eslint"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!/node_modules/",
+      "!src/index.js"
+    ]
   }
 }


### PR DESCRIPTION
### What does this PR do?

Bump coverage report by ignoring src/index.js




#### What are the relevant Github Issues ?
Fixes #299 


