### PR TITLE
Add cypress tests for the Artists route

### DIFF
--- a/cypress/integration/Artists.feature
+++ b/cypress/integration/Artists.feature
@@ -1,0 +1,19 @@
+Feature: Artists
+
+   As User
+   If I click the Artists link
+   I should be able to see the artist page
+  
+  Background: Home page
+    Given I am on the home page
+
+   @focus
+  Scenario: Visit from artist link on the nav bar
+    
+    When I click on 'artist' link
+    Then I should be on the 'artist' page
+  
+  @focus
+  Scenario: Visit artists page from from link in the footer
+    When I click on 'artist' link on the footer
+    Then I should be on the 'artist' page

--- a/cypress/integration/DocumentTitle.feature
+++ b/cypress/integration/DocumentTitle.feature
@@ -1,10 +1,9 @@
 Feature: Page Title
-   
-   As a user
-   I should see 'Sing For Needs' as document title for all pages
-   Whenever a page loads
+  As a user
+  I should see 'Sing For Needs' as document title for all pages
+  Whenever a page loads
 
-   @focus
+  @focus
   Scenario: visitig home page
-    Given I visit the home page
+    Given I am on the home page
     Then I should see 'Sing For Needs' as document title

--- a/cypress/integration/common/web_steps.js
+++ b/cypress/integration/common/web_steps.js
@@ -25,10 +25,11 @@ When("I click on 'artist' link on the footer", () => {
 })
 
 Then("I should be on the 'artist' page", () => {
-  cy.url()
-    .should('contain', '/artists')
-  cy.get('.trending-artists-title')
-    .should('contain', 'Trending Artists')
-  cy.get('.explore-artists-title')
-    .should('contain', 'Explore Artists')
+  cy.url().should('contain', '/artists')
+  cy.get('.trending-artists-title').should('contain', 'Trending Artists')
+  cy.get('.explore-artists-title').should('contain', 'Explore Artists')
+})
+
+Then("I should see 'Sing For Needs' as document title", () => {
+  cy.title().should('contain', 'Sing for Needs')
 })

--- a/cypress/integration/common/web_steps.js
+++ b/cypress/integration/common/web_steps.js
@@ -1,6 +1,34 @@
-import { Given } from 'cypress-cucumber-preprocessor/steps'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 const url = 'https://google.com'
 Given('I open Google page', () => {
   cy.visit(url)
+})
+
+Given('I am on the home page', () => {
+  cy.visit('/')
+})
+
+When("I click on 'artist' link", () => {
+  cy.get('.nav-container__left')
+    .find('a')
+    .contains('Artists')
+    .click()
+})
+
+When("I click on 'artist' link on the footer", () => {
+  cy.get('.footer__container')
+    .find('nav')
+    .find('a')
+    .contains('Artists')
+    .click()
+})
+
+Then("I should be on the 'artist' page", () => {
+  cy.url()
+    .should('contain', '/artists')
+  cy.get('.trending-artists-title')
+    .should('contain', 'Trending Artists')
+  cy.get('.explore-artists-title')
+    .should('contain', 'Explore Artists')
 })


### PR DESCRIPTION
### What does this PR do?

Adds cypress tests to test Users journey to access the artist page



#### How should this be manually tested?

1. On terminal, run command `yarn e2e:local`



#### What are the relevant Github Issues ?
Fixes #286 

