### PR TITLE
Bump test coverage of donate block

### DIFF
--- a/src/components/Cause/Donate/DonateBlock.test.js
+++ b/src/components/Cause/Donate/DonateBlock.test.js
@@ -33,4 +33,11 @@ describe('<DonateBlock />', () => {
   it('has an add to cart button to put donation amount in the cart', () => {
     expect(donateBlockWrapper.find('button.add-to-cart').length).toEqual(1)
   })
+
+  it('changes state of amount when input typed', () => {
+    const wrapper = shallow(<DonateBlock />)
+    const input = wrapper.find('input')
+    input.simulate('change', { target: { value: '$585' } })
+    expect(wrapper.state().amount).toEqual('$585')
+  })
 })


### PR DESCRIPTION

### What does this PR do?

- Test the change event on the text input




#### Description of Task to be completed?

Moves test coverage of donate Block to 100%


#### How should this be manually tested?

1. On terminal, run command `yarn test:coverage`


#### Any background context you want to provide?




#### What are the relevant Github Issues ?
Fixes #328 


#### Screenshots (If applicable)


