### PR TITLE
Add explore all section to the Performances page

### DIFF
--- a/src/containers/Performances/ExplorePerformances/ExplorePerformances.js
+++ b/src/containers/Performances/ExplorePerformances/ExplorePerformances.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+import Paginate from '../../../components/Paginate/Paginate'
+
+class ExplorePerformances extends Component {
+  render() {
+    return (
+      <React.Fragment>
+        <h1 className="explore-performances-title" >Explore Performances</h1>
+        <Paginate />
+      </React.Fragment>
+    )
+  }
+}
+
+export default ExplorePerformances

--- a/src/containers/Performances/ExplorePerformances/ExplorePerformances.scss
+++ b/src/containers/Performances/ExplorePerformances/ExplorePerformances.scss
@@ -1,0 +1,12 @@
+.explore-performances-title {
+  text-align: center;
+  grid-column-end: span 12;
+  padding: $padding-s;
+  color: $primary-color-white;
+  margin-top: $margin-l;
+}
+
+.pagination {
+  grid-column: -1 / 1;
+  display: flex;
+}

--- a/src/containers/Performances/ExplorePerformances/ExplorePerformances.test.js
+++ b/src/containers/Performances/ExplorePerformances/ExplorePerformances.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ExplorePerformances from './ExplorePerformances'
+import Paginate from '../../../components/Paginate/Paginate'
+
+describe('<ExplorePerformances />', () => {
+  let explorePerformancesWrapper
+  beforeEach(() => {
+    explorePerformancesWrapper = shallow(<ExplorePerformances />)
+  })
+  it("has 'Explore Performances' title", () => {
+    expect(explorePerformancesWrapper.find('h1').text()).toEqual('Explore Performances')
+  })
+  it('has a Paginate component', () => {
+    expect(explorePerformancesWrapper.find(Paginate).length).toEqual(1)
+  })
+})

--- a/src/containers/Performances/Performances.js
+++ b/src/containers/Performances/Performances.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
+import ExplorePerformances from './ExplorePerformances/ExplorePerformances'
 import Banner from '../../components/Shared/Banner/Banner'
 
 class Performances extends Component {
   render() {
     return (
       <React.Fragment>
+        <ExplorePerformances />
         <Banner
           headline="You can make a difference today"
           buttonLabel="Sign up now"

--- a/src/containers/Performances/Performances.test.js
+++ b/src/containers/Performances/Performances.test.js
@@ -7,6 +7,9 @@ describe('<Performances />', () => {
   beforeEach(() => {
     performancesWrapper = shallow(<Performances />)
   })
+  it('contains an ExploreArtists section', () => {
+    expect(performancesWrapper.find('ExplorePerformances').length).toEqual(1)
+  })
   it('contains a sign up banner at the bottom', () => {
     expect(performancesWrapper.find('Banner').length).toEqual(1)
   })

--- a/src/main.scss
+++ b/src/main.scss
@@ -48,3 +48,4 @@
 @import "components/About/How/How.scss";
 @import "components/Contact/ContactDetails/ContactDetails.scss";
 @import "components/Contact/ContactForm/ContactForm.scss";
+@import "containers/Performances/ExplorePerformances/ExplorePerformances.scss"


### PR DESCRIPTION
### What does this PR do?
Adds the Explore All Performances section to the Performances page.

#### What are the relevant Github Issues ?
Fixes #322 

