### PR TITLE
Adding performance carousel to performance page

### DIFF
--- a/src/components/Performance/PerformanceBio/PerformanceBio.js
+++ b/src/components/Performance/PerformanceBio/PerformanceBio.js
@@ -1,7 +1,12 @@
 import React from 'react'
+import PerformanceCarousel from './PerformanceCarousel'
 
 const PerformanceBio = () => {
-  return <React.Fragment>PerformanceBio</React.Fragment>
+  return (
+    <React.Fragment>
+      <PerformanceCarousel />
+    </React.Fragment>
+  )
 }
 
 export default PerformanceBio

--- a/src/components/Performance/PerformanceBio/PerformanceBio.test.js
+++ b/src/components/Performance/PerformanceBio/PerformanceBio.test.js
@@ -10,7 +10,7 @@ describe('<PerformanceBio />', () => {
     performanceBioWrapper = shallow(<PerformanceBio />)
   })
 
-  it('has the text PerformanceBio written', () => {
-    expect(performanceBioWrapper.text()).toEqual('PerformanceBio')
+  it('has a <PerformanceCarousel /> element', () => {
+    expect(performanceBioWrapper.find('PerformanceCarousel')).toHaveLength(1)
   })
 })

--- a/src/components/Performance/PerformanceBio/PerformanceCarousel.js
+++ b/src/components/Performance/PerformanceBio/PerformanceCarousel.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCaretLeft, faCaretRight } from '@fortawesome/free-solid-svg-icons'
+
+class PerformanceCarousel extends React.Component {
+  state = {
+    currentSlide: 0,
+    totalSlides: null
+  };
+
+  componentDidMount() {
+    this.setState({
+      totalSlides: document.querySelectorAll('.performance-slide').length
+    })
+  }
+
+  moveSlide = slide => {
+    const slideShowHolder = document.querySelector(
+      '.performanceslideshow-holder'
+    )
+    const leftPosition = -slide * 550 + 'px'
+
+    slideShowHolder.style.left = `${leftPosition}`
+  };
+
+  slideCarouselRight = () => {
+    const nextSlide = this.state.currentSlide + 1
+
+    if (nextSlide > this.state.totalSlides - 1) {
+      this.setState({
+        currentSlide: 0
+      })
+      this.moveSlide(0)
+    } else {
+      this.setState({
+        currentSlide: nextSlide
+      })
+      this.moveSlide(nextSlide)
+    }
+  };
+
+  slideCarouselLeft = () => {
+    const nextSlide = this.state.currentSlide - 1
+
+    if (nextSlide < 0) {
+      this.setState({
+        currentSlide: this.state.totalSlides - 1
+      })
+      this.moveSlide(this.state.totalSlides - 1)
+    } else {
+      this.setState({
+        currentSlide: nextSlide
+      })
+      this.moveSlide(nextSlide)
+    }
+  };
+
+  render() {
+    return (
+      <div className="performance-slideshow">
+        <div className="performanceslideshow-holder">
+          <div className="performance-slide performance-slide-1" />
+          <div className="performance-slide performance-slide-2" />
+          <div className="performance-slide performance-slide-3" />
+          <div className="performance-slide performance-slide-4" />
+        </div>
+        <div className="carousel-navigation">
+          <button className="prev" onClick={() => this.slideCarouselLeft()}>
+            <FontAwesomeIcon
+              className="supported-performances-item-list__icon"
+              icon={faCaretLeft}
+            />
+          </button>
+          <button className="next" onClick={() => this.slideCarouselRight()}>
+            <FontAwesomeIcon
+              className="supported-performances-item-list__icon"
+              icon={faCaretRight}
+            />
+          </button>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default PerformanceCarousel

--- a/src/components/Performance/PerformanceBio/PerformanceCarousel.scss
+++ b/src/components/Performance/PerformanceBio/PerformanceCarousel.scss
@@ -1,0 +1,93 @@
+.performance-slideshow {
+  grid-column: 1/7;
+  height: 300px;
+  margin-bottom: $margin-l;
+  margin-top: $margin-l;
+  overflow: hidden;
+  position: relative;
+
+  .performanceslideshow-holder {
+    width: 10000vw;
+    height: 100%;
+    position: relative;
+    top: 0;
+    left: 0px;
+    display: flex;
+    transition: left 300ms ease;
+  }
+
+  .carousel-navigation {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    padding-left: $padding-s;
+    padding-right: $padding-s;
+    transform: translateY(-50%);
+
+    .prev,
+    .next {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: $primary-color-darkblue;
+      border-radius: 50%;
+      width: 32px;
+      height: 32px;
+
+      &:hover {
+        cursor: pointer;
+        background-color: $primary-color-white;
+      }
+    }
+
+    .prev:hover svg,
+    .next:hover svg {
+      color: $primary-color-darkblue;
+    }
+
+    svg {
+      margin-right: 0;
+    }
+  }
+
+  .performance-slide {
+    width: 550px;
+    height: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      bottom: 0px;
+      height: 100%;
+      width: 100%;
+      background-image: linear-gradient(
+        to top,
+        $primary-color-darkblue,
+        rgba($primary-color-darkblue-lighter, 0)
+      );
+    }
+  }
+
+  .performance-slide-1 {
+    background-image: url("/images/cause_sample.jpg");
+  }
+
+  .performance-slide-2 {
+    background-color: purple;
+  }
+
+  .performance-slide-3 {
+    background-color: green;
+  }
+
+  .performance-slide-4 {
+    background-color: brown;
+  }
+}

--- a/src/components/Performance/PerformanceBio/PerformanceCarousel.test.js
+++ b/src/components/Performance/PerformanceBio/PerformanceCarousel.test.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import PerformanceCarousel from './PerformanceCarousel'
+
+import { mount } from 'enzyme'
+
+describe('<PerformanceCarousel />', () => {
+  let performanceCarouselWrapper
+  let querySelector
+
+  beforeEach(() => {
+    performanceCarouselWrapper = mount(<PerformanceCarousel />)
+    querySelector = jest.fn().mockReturnValue({ style: {} })
+    Object.defineProperty(global.document, 'querySelector', {
+      writable: true,
+      value: querySelector
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('has 4 images rendered within the carousel', () => {
+    expect(performanceCarouselWrapper.find('.performance-slide')).toHaveLength(
+      4
+    )
+  })
+
+  it('has a button to move the carousel left', () => {
+    expect(performanceCarouselWrapper.find('.prev')).toHaveLength(1)
+  })
+
+  it('has a button to move the carousel right', () => {
+    expect(performanceCarouselWrapper.find('.next')).toHaveLength(1)
+  })
+
+  it('calls moveSlide when next is clicked', () => {
+    performanceCarouselWrapper.find('.next').simulate('click')
+    expect(querySelector).toHaveBeenCalledTimes(1)
+    expect(querySelector).toHaveBeenCalledWith('.performanceslideshow-holder')
+  })
+
+  it('calls slideCarouselLeft when previous is clicked', () => {
+    performanceCarouselWrapper.find('.prev').simulate('click')
+    expect(querySelector).toHaveBeenCalledTimes(1)
+    expect(querySelector).toHaveBeenCalledWith('.performanceslideshow-holder')
+  })
+
+  it('moves slide left when previous button is clicked', () => {
+    performanceCarouselWrapper.find('.prev').simulate('click')
+    expect(performanceCarouselWrapper.state().currentSlide).toEqual(-1)
+  })
+
+  it('moves slide right when next button is clicked', () => {
+    performanceCarouselWrapper.setState({ currentSlide: 0, totalSlides: 4 })
+    performanceCarouselWrapper.find('.next').simulate('click')
+    expect(performanceCarouselWrapper.state().currentSlide).toEqual(1)
+  })
+
+  it('resets slide to 0 when next is clicked at the end of the slide stack', () => {
+    performanceCarouselWrapper.setState({ currentSlide: 2, totalSlides: 2 })
+    performanceCarouselWrapper.find('.next').simulate('click')
+    expect(performanceCarouselWrapper.state().currentSlide).toEqual(0)
+  })
+
+  it('moves slide to the left when prev is clicked and current slide is not the first slide', () => {
+    performanceCarouselWrapper.setState({ currentSlide: 2, totalSlides: 2 })
+    performanceCarouselWrapper.find('.prev').simulate('click')
+    expect(performanceCarouselWrapper.state().currentSlide).toEqual(1)
+  })
+})

--- a/src/containers/Performance/Performance.js
+++ b/src/containers/Performance/Performance.js
@@ -4,9 +4,9 @@ import PerformanceBio from '../../components/Performance/PerformanceBio/Performa
 class Performance extends Component {
   render() {
     return (
-      <div>
+      <React.Fragment>
         <PerformanceBio />
-      </div>
+      </React.Fragment>
     )
   }
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -42,6 +42,7 @@
 @import "components/Cause/ContactUs/ContactUs.scss";
 @import "components/Cause/SupportingArtist/SupportingArtist.scss";
 @import "components/Cause/RelatedCause/RelatedCause.scss";
+@import "components/Performance/PerformanceBio/PerformanceCarousel.scss";
 @import "components/Causes/CauseCard/CauseCard.scss";
 @import "components/Performances/PerformanceCard/PerformanceCard.scss";
 @import "components/Shared/Avatar/Avatar.scss";


### PR DESCRIPTION
### What does this PR do?
- Performance carousel is added to performance page

#### Description of Task to be completed?
- Performance carousel is working on the individual performance page

#### How should this be manually tested?

The regular forked repo testing method should work in this case.

#### Any background context you want to provide?

We'll need later an additional ticket to refactor carousel to a separate shared component used by both the cause and the performance page.

#### What are the relevant Github Issues ?

Fixes #379 

#### Screenshots (If applicable)
![Screen Shot 2019-08-25 at 7 39 10 PM](https://user-images.githubusercontent.com/9334646/63653676-3e7aa380-c770-11e9-9351-2f1cbd05cfb3.png)

