### PR TITLE
Adding PerformanceBioDetail component to Performance page

### DIFF
--- a/src/components/Performance/PerformanceBio/PerformanceBio.js
+++ b/src/components/Performance/PerformanceBio/PerformanceBio.js
@@ -1,10 +1,16 @@
 import React from 'react'
 import PerformanceCarousel from './PerformanceCarousel'
+import PerformanceBioDetail from './PerformanceBioDetail'
 
 const PerformanceBio = () => {
+  const content =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+
   return (
     <React.Fragment>
       <PerformanceCarousel />
+      <PerformanceBioDetail heading="About the Performance" content={content} />
+      <PerformanceBioDetail heading="About the Artist" content={content} />
     </React.Fragment>
   )
 }

--- a/src/components/Performance/PerformanceBio/PerformanceBio.test.js
+++ b/src/components/Performance/PerformanceBio/PerformanceBio.test.js
@@ -13,4 +13,8 @@ describe('<PerformanceBio />', () => {
   it('has a <PerformanceCarousel /> element', () => {
     expect(performanceBioWrapper.find('PerformanceCarousel')).toHaveLength(1)
   })
+
+  it('has 2 <PerformanceBioDetail /> components', () => {
+    expect(performanceBioWrapper.find('PerformanceBioDetail')).toHaveLength(2)
+  })
 })

--- a/src/components/Performance/PerformanceBio/PerformanceBioDetail.js
+++ b/src/components/Performance/PerformanceBio/PerformanceBioDetail.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const PerformanceBioDetail = props => {
+  return (
+    <div className="performance-bio-detail-container">
+      <h5 className="white performance-bio-detail__heading">{props.heading}</h5>
+      <p className="white performance-bio-detail__content">{props.content}</p>
+    </div>
+  )
+}
+
+PerformanceBioDetail.propTypes = {
+  heading: PropTypes.string,
+  content: PropTypes.string
+}
+export default PerformanceBioDetail

--- a/src/components/Performance/PerformanceBio/PerformanceBioDetail.scss
+++ b/src/components/Performance/PerformanceBio/PerformanceBioDetail.scss
@@ -1,0 +1,12 @@
+.performance-bio-detail-container {
+  grid-column: 1/6;
+  margin-bottom: $margin-l;
+
+  .performance-bio-detail__content {
+    margin-bottom: 0;
+  }
+
+  .performance-bio-detail__heading {
+    margin-bottom: $margin-s;
+  }
+}

--- a/src/components/Performance/PerformanceBio/PerformanceBioDetail.test.js
+++ b/src/components/Performance/PerformanceBio/PerformanceBioDetail.test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import PerformanceBioDetail from './PerformanceBioDetail'
+
+describe('<PerformanceBioDetail/>', () => {
+  let performanceBioDetailWrapper
+  let props = {
+    heading: 'Heading',
+    content: 'Content'
+  }
+  beforeEach(() => {
+    performanceBioDetailWrapper = shallow(<PerformanceBioDetail {...props} />)
+  })
+
+  it('has <h5> element with text Heading', () => {
+    expect(performanceBioDetailWrapper.find('h5').text()).toEqual('Heading')
+  })
+
+  it('has <p> element with text Content', () => {
+    expect(performanceBioDetailWrapper.find('p').text()).toEqual('Content')
+  })
+})

--- a/src/main.scss
+++ b/src/main.scss
@@ -43,6 +43,7 @@
 @import "components/Cause/SupportingArtist/SupportingArtist.scss";
 @import "components/Cause/RelatedCause/RelatedCause.scss";
 @import "components/Performance/PerformanceBio/PerformanceCarousel.scss";
+@import "components/Performance/PerformanceBio/PerformanceBioDetail.scss";
 @import "components/Causes/CauseCard/CauseCard.scss";
 @import "components/Performances/PerformanceCard/PerformanceCard.scss";
 @import "components/Shared/Avatar/Avatar.scss";


### PR DESCRIPTION
### What does this PR do?
- Adding PerformanceBioDetail component to Performance page

#### Description of Task to be completed?
- PerformanceBioDetail contains some dummy data on artist and performance

#### How should this be manually tested?

The regular forked testing should be sufficient

#### What are the relevant Github Issues ?
Fixes #381 

#### Screenshots (If applicable)

![Screen Shot 2019-08-25 at 7 55 09 PM](https://user-images.githubusercontent.com/9334646/63653882-09bc1b80-c773-11e9-9caf-131fde4b768b.png)

