### PR TITLE
Adding attendance to performance

### DIFF
--- a/src/containers/Performance/Attendance/Attendance.js
+++ b/src/containers/Performance/Attendance/Attendance.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react'
+import Avatar from '../../../components/Shared/Avatar/Avatar'
+class Attendance extends Component {
+  render() {
+    return (
+      <div className="attendance-wrapper">
+        <h5 className="white">Who's attending?</h5>
+        <div className="attendance__avatars">
+          <Avatar />
+          <Avatar />
+          <Avatar />
+          <Avatar />
+          <Avatar />
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Attendance

--- a/src/containers/Performance/Attendance/Attendance.scss
+++ b/src/containers/Performance/Attendance/Attendance.scss
@@ -1,0 +1,10 @@
+.attendance-wrapper {
+  grid-column: 7/-1;
+  grid-row: 2;
+  margin-left: $margin-l;
+}
+
+.attendance__avatars {
+  display: flex;
+  margin-top: $margin-s;
+}

--- a/src/containers/Performance/Attendance/Attendance.test.js
+++ b/src/containers/Performance/Attendance/Attendance.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import Attendance from './Attendance'
+
+import { shallow } from 'enzyme'
+
+describe('<Attendance />', () => {
+  let attendanceWrapper
+
+  beforeEach(() => {
+    attendanceWrapper = shallow(<Attendance />)
+  })
+
+  it("has the title Who's attending?", () => {
+    expect(attendanceWrapper.find('h5').text()).toEqual("Who's attending?")
+  })
+
+  it('has 5 people attending the event', () => {
+    expect(attendanceWrapper.find('Avatar').length).toEqual(5)
+  })
+})

--- a/src/containers/Performance/Performance.js
+++ b/src/containers/Performance/Performance.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PerformanceBio from '../../components/Performance/PerformanceBio/PerformanceBio'
 import Campaign from '../../components/Shared/Campaign/Campaign'
+import Attendance from './Attendance/Attendance'
 
 class Performance extends Component {
   render() {
@@ -14,6 +15,7 @@ class Performance extends Component {
           daysToGo={23}
           organization="Beyonce"
         />
+        <Attendance />
       </React.Fragment>
     )
   }

--- a/src/containers/Performance/Performance.test.js
+++ b/src/containers/Performance/Performance.test.js
@@ -17,4 +17,8 @@ describe('<Performance />', () => {
   it('contains a Campaign component', () => {
     expect(performanceWrapper.find('Campaign').length).toEqual(1)
   })
+
+  it('contains an Attendance component', () => {
+    expect(performanceWrapper.find('Attendance').length).toEqual(1)
+  })
 })

--- a/src/main.scss
+++ b/src/main.scss
@@ -42,10 +42,11 @@
 @import "components/Cause/ContactUs/ContactUs.scss";
 @import "components/Cause/SupportingArtist/SupportingArtist.scss";
 @import "components/Cause/RelatedCause/RelatedCause.scss";
+@import "components/Causes/CauseCard/CauseCard.scss";
 @import "components/Performance/PerformanceBio/PerformanceCarousel.scss";
 @import "components/Performance/PerformanceBio/PerformanceBioDetail.scss";
-@import "components/Causes/CauseCard/CauseCard.scss";
 @import "components/Performances/PerformanceCard/PerformanceCard.scss";
+@import "containers/Performance/Attendance/Attendance.scss";
 @import "components/Shared/Avatar/Avatar.scss";
 @import "components/About/Vision/Vision.scss";
 @import "components/About/Why/Why.scss";


### PR DESCRIPTION
### What does this PR do?
- Adding attendance component to performance page

#### Description of Task to be completed?
- Avatars are showing up with the faces who are attending the performance

#### How should this be manually tested?

Forked repo method should be sufficient to test it.

#### What are the relevant Github Issues ?

Fixes #382 

#### Screenshots (If applicable)

![Screen Shot 2019-08-27 at 10 07 00 PM](https://user-images.githubusercontent.com/9334646/63804228-03ff3b00-c917-11e9-9860-6c11dc9ab95e.png)


