### PR TITLE
progress bar active max-width 100%

### DIFF
--- a/src/components/Causes/CauseCard/CauseCard.scss
+++ b/src/components/Causes/CauseCard/CauseCard.scss
@@ -62,6 +62,7 @@
 
     .cause-card-progress-bar-active {
       width: 0;
+      max-width: 100%;
       height: 100%;
       background-color: $primary-color-accent;
     }


### PR DESCRIPTION
### What does this PR do?
Adds a max-width to the progress-bar-active in the Cause Card SCSS file.

#### How should this be manually tested?
By manually setting the cause card progress variable to over 100%

#### What are the relevant Github Issues ?
This resolves issue 441.
